### PR TITLE
Fix flaky test in com.google.inject.throwingproviders.CheckedProviderTest

### DIFF
--- a/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java
+++ b/extensions/throwingproviders/test/com/google/inject/throwingproviders/CheckedProviderTest.java
@@ -23,6 +23,7 @@ import static com.google.inject.Asserts.assertContains;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.assertArrayEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -554,11 +555,29 @@ public class CheckedProviderTest extends TestCase {
           });
       fail();
     } catch (CreationException expected) {
-      assertEquals(
-          RemoteProviderWithExtraMethod.class.getName()
-              + " may not declare any new methods, but declared "
-              + RemoteProviderWithExtraMethod.class.getDeclaredMethods()[0].toGenericString(),
-          Iterables.getOnlyElement(expected.getErrorMessages()).getMessage());
+      String expectedMessage = RemoteProviderWithExtraMethod.class.getName()
+          + " may not declare any new methods, but declared "
+          + RemoteProviderWithExtraMethod.class.getDeclaredMethods()[0].toGenericString();
+          
+      String actualMessage = Iterables.getOnlyElement(expected.getErrorMessages()).getMessage();
+
+      if (actualMessage.contains("throws")) {
+        String[] expectedStrs = expectedMessage.split("throws\\s*");
+        String[] actualStrs = actualMessage.split("throws\\s*");
+
+        assertEquals(expectedStrs[0], actualStrs[0]);
+
+        String[] expectedExceptions = expectedStrs.length > 1 ? expectedStrs[1].split(",\\s*") : new String[0];
+        String[] actualExceptions = actualStrs.length > 1 ? actualStrs[1].split(",\\s*") : new String[0];
+
+        Arrays.sort(expectedExceptions);
+        Arrays.sort(actualExceptions);
+
+        assertArrayEquals(expectedExceptions, actualExceptions);
+      }
+      else {
+        assertEquals(expectedMessage, actualMessage);
+      }
     }
   }
 


### PR DESCRIPTION
### Description
The tests in the test class `com.google.inject.throwingproviders.CheckedProviderTest` could fail because the code assumes deterministic implementation of a non-deterministic specification

### Steps to reproduce
Compile the module where the test is, and all modules it depends on, but skip tests
```
mvn install -pl extensions/throwingproviders -am -DskipTests
```
Run the test to check that it passes
```
mvn -pl extensions/throwingproviders test -Dtest=com.google.inject.throwingproviders.CheckedProviderTest#testBindingToInterfaceWithExtraMethod_Provides
```
Run the test with the NonDex tool
```
mvn -pl extensions/throwingproviders edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.google.inject.throwingproviders.CheckedProviderTest#testBindingToInterfaceWithExtraMethod_Provides
```

### Expected Behaviour
All tests should pass

### Actual Behaviour
Detected test failure with the following NonDex configuration:
nondexFilter=.*
nondexMode=FULL
nondexSeed=933178
nondexStart=0
nondexEnd=9223372036854775807
nondexPrintstack=false

The test is failing due to a non-deterministic order between the two exception types:
Expected: ....get(T) throws java.[net.BindException,java.rmi.Remote]Exception
Actual: ....get(T) throws java.[rmi.RemoteException,java.net.Bind]Exception

### Findings
The test `com.google.inject.throwingproviders.CheckedProviderTest.testBindingToInterfaceWithExtraMethod_Provides` was failing because it was using `toGenericString()` method of the `java.lang.reflect.Method` class to provide a string representation of the method’s generic signature, including any exceptions that the method might throw. However, `java.lang.reflect.Method` class documentation does not guarantee the order in which exceptions are reported in the `toGenericString()` output. Therefore, if the test assumes a particular order but the actual order differs, the test will fail.

### Fix
We can split the error messages by "throws" to extract the exception strings from the expected string and the actual string. Then we can sort the exceptions before comparing them. In this way, the test will be no longer affected by the arbitrary order of exceptions.